### PR TITLE
Aceita CEPs com hífen

### DIFF
--- a/correios_server.py
+++ b/correios_server.py
@@ -34,33 +34,30 @@ def _get_info_from_correios(cep):
 
 
 
-@route('/cep/<cep>')
+@route('/cep/<cep:re:\d{5}-?\d{3}>')
 def verifica_cep(cep):
-
+	cep = cep.replace('-', '')
 	try:
-		if re.match('[0-9]{8}', cep):
-			con = pymongo.MongoClient('localhost')
-			db = con.postmon
-			ceps = db.ceps
-			result = ceps.find_one({'cep':cep}, fields={'_id':False})
+		con = pymongo.MongoClient('localhost')
+		db = con.postmon
+		ceps = db.ceps
+		result = ceps.find_one({'cep':cep}, fields={'_id':False})
 
-			from datetime import date
+		from datetime import date
 
-			info = None
-			
-			if not result or not result.has_key('v_date'):
-				info = _get_info_from_correios(cep)
-				map(lambda x: ceps.save(x), info)
-				result = ceps.find_one({'cep':cep}, fields={'_id':False, 'v_date':False})
+		info = None
+		
+		if not result or not result.has_key('v_date'):
+			info = _get_info_from_correios(cep)
+			map(lambda x: ceps.save(x), info)
+			result = ceps.find_one({'cep':cep}, fields={'_id':False, 'v_date':False})
 
-			elif expired(result):
-				info = _get_info_from_correios(cep)
-				map(lambda x: ceps.update({'cep': x['cep']}, {'$set':x}), info)
-				result = ceps.find_one({'cep':cep}, fields={'_id':False,'v_date':False})
-			else:
-				result = ceps.find_one({'cep':cep}, fields={'_id':False,'v_date':False})
+		elif expired(result):
+			info = _get_info_from_correios(cep)
+			map(lambda x: ceps.update({'cep': x['cep']}, {'$set':x}), info)
+			result = ceps.find_one({'cep':cep}, fields={'_id':False,'v_date':False})
 		else:
-			raise ValueError()
+			result = ceps.find_one({'cep':cep}, fields={'_id':False,'v_date':False})
 
 	except ValueError:
 		result = dict(status='error',


### PR DESCRIPTION
Usa filtro do bottle na definição da rota para definir o formato do CEP, aceitando 11111111 ou 11111-111. Remove o hifen para aproveitar o cache no pymongo.
