### PR TITLE
Key `endereco` ao invés de `endereço`.

### DIFF
--- a/CepTracker.py
+++ b/CepTracker.py
@@ -65,6 +65,10 @@ class CepTracker():
                     logradouro, complemento = value.split(' - ', 1)
                     data['logradouro'] = logradouro.strip()
                     data['complemento'] = complemento.strip(' -')
+                elif label == u'endereço':
+                    # Use sempre a key `endereco`. O `endereço` existe para não
+                    # quebrar clientes existentes. #92
+                    data['endereco'] = data[label] = value
                 else:
                     data[label] = value
 

--- a/database.py
+++ b/database.py
@@ -23,7 +23,12 @@ class MongoDb(object):
         self._db = self._client.postmon
 
     def get_one(self, cep, **kwargs):
-        return self._db.ceps.find_one({'cep': cep}, **kwargs)
+        r = self._db.ceps.find_one({'cep': cep}, **kwargs)
+        if r and u'endereço' in r and 'endereco' not in r:
+            # Garante que o cache também tem a key `endereco`. #92
+            # Novos resultados já são adicionados corretamente.
+            r['endereco'] = r[u'endereço']
+        return r
 
     def get_one_uf(self, sigla, **kwargs):
         return self._db.ufs.find_one({'sigla': sigla}, **kwargs)


### PR DESCRIPTION
Mantém a key `endereço`, para manter compatilibidade com clientes
já existentes. Fix #92
