### PR TITLE
_get_info_from_source não precisa lançar ValueError

### DIFF
--- a/PostmonServer.py
+++ b/PostmonServer.py
@@ -7,7 +7,7 @@ import xmltodict
 from bottle import route, run, response, template, HTTPResponse
 from CepTracker import CepTracker
 import requests
-from packtrack import Correios, Royal
+from packtrack import Correios
 from database import MongoDb as Database
 
 
@@ -33,10 +33,7 @@ def expired(record_date):
 
 def _get_info_from_source(cep):
     tracker = CepTracker()
-    info = tracker.track(cep)
-    if len(info) == 0:
-        raise ValueError('CEP %s nao encontrado' % cep)
-    return info
+    return tracker.track(cep)
 
 
 def format_result(result):
@@ -100,9 +97,6 @@ def verifica_cep(cep):
         result = None
         try:
             info = _get_info_from_source(cep)
-        except ValueError:
-            message = '404 CEP %s nao encontrado' % cep
-            logger.exception(message)
         except requests.exceptions.RequestException:
             message = '503 Servico Temporariamente Indisponivel'
             logger.exception(message)

--- a/test/postmon_test.py
+++ b/test/postmon_test.py
@@ -212,7 +212,7 @@ class PostmonErrors(unittest.TestCase):
 
     @mock.patch('PostmonServer._get_info_from_source')
     def test_404_status(self, _mock):
-        _mock.side_effect = ValueError('test')
+        _mock.return_value = []
         response = self.get_cep('99999999', expect_errors=True)
         self.assertEqual("404 CEP 99999999 nao encontrado", response.status)
         self.assertEqual('application/json', response.headers['Content-Type'])
@@ -220,7 +220,7 @@ class PostmonErrors(unittest.TestCase):
 
     @mock.patch('PostmonServer._get_info_from_source')
     def test_404_status_with_xml_format(self, _mock):
-        _mock.side_effect = ValueError('test')
+        _mock.return_value = []
         response = self.get_cep('99999999', format='xml', expect_errors=True)
         self.assertEqual("404 CEP 99999999 nao encontrado", response.status)
         self.assertEqual('application/xml', response.headers['Content-Type'])


### PR DESCRIPTION
A própria rota de CEP já trata o caso de CEP não existir. Isso não é um erro, logar como warning ou até info é melhor.
