### PR TITLE
fix Dockerfile to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get -y update -qq&& \
 	libpython2.7-dev \
 	python-pip
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip==18.0
 
-RUN pip install --upgrade setuptools wheel
+RUN pip install setuptools wheel
 
 ENV APP_DIR /srv/postmon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get -y update -qq&& \
 	libpython2.7-dev \
 	python-pip
 
-RUN pip install --upgrade pip==18.0 setuptools wheel
+RUN pip install --upgrade pip
+
+RUN pip install --upgrade setuptools wheel
 
 ENV APP_DIR /srv/postmon
 


### PR DESCRIPTION
Ao rodar o dockerbuild ele apresentava os seguintes erros:

- Command "python setup.py egg_info" failed with error code 32 in /tmp/pip-build-RoeTLE/setuptools/
- You are using pip version 8.1.1, however version 20.1.1 is available.
- You should consider upgrading via the 'pip install --upgrade pip' command.

Resolvi separando em outra camada o upgrade do restante das instalações, mantive a versão 18.0 embora na primeira tentativa de correção eu removi a versão e instalou a 20.1.1 e funcionou corretamente.