### PR TITLE
Trava a versão da lib 'Unidecode' na versão 1.2 ainda compativel com python 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.20.0
 raven==5.11.1
 newrelic==2.66.0.49
 unicode_slugify==0.1.3
+Unidecode==1.2.0


### PR DESCRIPTION
Trava a versão da lib 'Unidecode' na versão 1.2 ainda compativel com python 2